### PR TITLE
Feat/jobrunner/containerise

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,19 @@
 version: "3.9"
 services:
+  jobrunner:
+    image: zaptross/zapcode-jobrunner:latest
+    restart: unless-stopped
+    build:
+      context: ./jobrunner
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_HOST: "mongo"
+    env_file:
+      - .env
+
   mongo:
     image: mongo
-    restart: always
+    restart: unless-stopped
     ports:
       - "${DATABASE_PORT}:${DATABASE_PORT}"
     environment:
@@ -11,10 +22,8 @@ services:
 
   mongo-express:
     image: mongo-express
-    restart: always
+    restart: unless-stopped
     ports:
       - 8081:8081
     environment:
-      # ME_CONFIG_MONGODB_ADMINUSERNAME: ${DATABASE_USER}
-      # ME_CONFIG_MONGODB_ADMINPASSWORD: ${DATABASE_PASSWORD}
       ME_CONFIG_MONGODB_URL: mongodb://${DATABASE_USER}:${DATABASE_PASSWORD}@mongo:${DATABASE_PORT}/

--- a/jobrunner/Dockerfile
+++ b/jobrunner/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12.2-alpine3.19
+
+WORKDIR /jobrunner
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "-u", "jobrunner.py"]


### PR DESCRIPTION
This PR:
* adds a convenient local dev way to run the jobrunner as a background process
* refactors the jobrunner to log time between jobs rather than continuously

![image](https://github.com/Zaptross/zap-code/assets/26305909/be0adb1f-998c-42cc-b179-1c07e3ec7808)
